### PR TITLE
Rewrite extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Window State Manager is a GNOME Shell extension to monitor window states (positi
 
 ### Limitations
  * Restore does not manage which windows are on top.  However, in testing to date the correct windows have always been shown on top.
- * Window state is saved every 5 seconds. So if a window was created or moved just before removing the device from dock, it's state might not get preserved.
  * State is saved in memory and is not preserved across restarts.
 
 Configuration

--- a/extension.js
+++ b/extension.js
@@ -93,14 +93,19 @@ export default class WindowStateManager extends Extension {
     }
   }
 
-  // Schedule refresh
+  /**
+   * This function ensures that the _refreshState function won't be called
+   * multiple times. This occurs when the layout is restored and that triggers
+   * one or more of the signals. This function will schedule the refresh after a
+   * few seconds and all events during this period is ignored.
+   */
   _scheduleRefresh(reason) {
     if (this._refreshPending) return
 
     Logger.debug(`Refresh scheduled. Reason: ${reason}`);
 
     // Group events triggred together and run refresh once
-    this._refreshPending = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 5000, () => {
+    this._refreshPending = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 2000, () => {
       this._refreshState();
       this._refreshPending = null;
       return GLib.SOURCE_REMOVE;

--- a/extension.js
+++ b/extension.js
@@ -7,7 +7,7 @@ import { WindowStates } from './lib/extension/windowstate.js';
 
 // Logging configuration
 const EXTENSION_LOG_NAME = 'Window State Manager';
-const LOG_LEVEL = Logger.LOG_LEVELS.DEBUG;
+const LOG_LEVEL = Logger.LOG_LEVELS.INFO;
 
 export default class WindowStateManager extends Extension {
   /**

--- a/extension.js
+++ b/extension.js
@@ -63,6 +63,10 @@ export default class WindowStateManager extends Extension {
     ];
 
     this._wmSignals = [
+      shellWm.connect("size-changed", () => {
+        Logger.debug("Signal: Size changed");
+        this._refreshState();
+      }),
       shellWm.connect("minimize", () => {
         Logger.debug("Signal: Minimize");
         this._refreshState();

--- a/extension.js
+++ b/extension.js
@@ -1,149 +1,14 @@
 import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
-import Meta from "gi://Meta"
-import GLib from "gi://GLib"
+import GLib from "gi://GLib";
 
-// The following are only used for logging
+import { Logger } from './lib/common/logger.js';
+import { WindowStates } from './lib/extension/windowstate.js';
+
+// Logging configuration
 const EXTENSION_LOG_NAME = 'Window State Manager';
-const START_TIME = GLib.DateTime.new_now_local().format_iso8601();
+const LOG_LEVEL = Logger.LOG_LEVELS.INFO;
 
-// Log levels
-const LOG_NOTHING = 0;
-const LOG_ERROR = 1;
-const LOG_INFO = 2;
-const LOG_DEBUG = 3;
-const LOG_EVERYTHING = 4;
-
-const LOG_LEVEL = LOG_ERROR;
-
-// State of each window
-class WindowState {
-  constructor(window, log) {
-    this._rect = window.get_frame_rect();
-    this._maximized = window.get_maximized();
-    this._minimized = window.minimized;
-
-    // The following are only used for logging
-    this._fullscreen = window.fullscreen;
-    this._id = window.get_id();
-    this._title = window.get_title();
-    this._log = log;
-    if (log >= LOG_INFO)
-      console.log(`${EXTENSION_LOG_NAME} Save ${this}`);
-  }
-
-  toString() {
-    const r = this._rect;
-    return `x:${r.x}, y:${r.y}, w:${r.width}, h:${r.height}, maximized:${this._maximized}, ` +
-      `minimized:${this._minimized}, fullscreen:${this._fullscreen}, id:${this._id}, title:${this._title}`;
-  }
-
-  restore(currentWindow) {
-    if (!this._equalRect(currentWindow)) {
-      if (currentWindow.get_maximized())
-        currentWindow.unmaximize(Meta.MaximizeFlags.BOTH);
-      this._moveResizeFrame(currentWindow);
-    }
-    this._setMaximized(currentWindow);
-    this._setMinimized(currentWindow);
-    this._logDifferences(currentWindow);
-  }
-
-  _equalRect(window) {
-    const r = window.get_frame_rect();
-    return this._rect.x === r.x && this._rect.y === r.y &&
-      this._rect.width === r.width && this._rect.height === r.height;
-  }
-
-  _moveResizeFrame(window) {
-    // Is it correct to set user_op => true?  Is this performing a user operation?
-    window.move_resize_frame(true, this._rect.x, this._rect.y, this._rect.width, this._rect.height);
-  }
-
-  _setMaximized(window) {
-    if (window.get_maximized() !== this._maximized) {
-      if (this._maximized)
-        window.maximize(this._maximized);
-      else
-        window.unmaximize(Meta.MaximizeFlags.BOTH);
-    }
-  }
-
-  _setMinimized(window) {
-    if (window.minimized !== this._minimized) {
-      if (this._minimized)
-        window.minimize();
-      else
-        window.unminimize();
-    }
-  }
-
-  _logDifferences(window) {
-    if (this._log >= LOG_ERROR) {
-      let hasDiffs = false;
-      if (window.minimized !== this._minimized) {
-        console.log(`${EXTENSION_LOG_NAME} Error: Wrong minimized: ${window.minimized()}, title:${this._title}`);
-        hasDiffs = true;
-      }
-      if (window.get_maximized() !== this._maximized) {
-        console.log(`${EXTENSION_LOG_NAME} Error: Wrong maximized: ${window.get_maximized()}, title:${this._title}`);
-        hasDiffs = true;
-      }
-      // This test fails when there is a difference between saved and current maximization, though the window
-      // behaviour is correct.  Due to an asynchronous update?
-      if (this._log >= LOG_EVERYTHING && !this._equalRect(window)) {
-        const r = window.get_frame_rect();
-        console.log(`${EXTENSION_LOG_NAME} Error: Wrong rectangle: x:${r.x}, y:${r.y}, w:${r.width}, h:${r.height}, title:${this._title}`);
-        hasDiffs = true;
-      }
-      if (hasDiffs)
-        console.log(`${EXTENSION_LOG_NAME} Expecting: ${this}`);
-    }
-  }
-}
-
-// State of all windows
-class AllWindowsStates {
-  constructor(log) {
-    this._log = log;
-  }
-
-  _getWindows() {
-    return global.get_window_actors().map(a => a.meta_window).filter(w => !w.is_skip_taskbar());
-  }
-
-  _getWindowStateMap(why) {
-    const size = global.display.get_size();
-    const displaySizeKey = size[0] * 100000 + size[1];
-    if (!displaySize__windowId__state.has(displaySizeKey))
-      displaySize__windowId__state.set(displaySizeKey, new Map());
-    const windowId__state = displaySize__windowId__state.get(displaySizeKey);
-    if (this._log >= LOG_DEBUG)
-      console.log(`${EXTENSION_LOG_NAME} ${why} map size: ${windowId__state.size}  display size: ${size}  start time: ${START_TIME}`);
-    return windowId__state;
-  }
-
-  saveWindowPositions(why) {
-    const windowId__state = this._getWindowStateMap(why);
-    windowId__state.clear();
-    for (const window of this._getWindows())
-      windowId__state.set(window.get_id(), new WindowState(window, this._log));
-  }
-
-  restoreWindowPositions(why) {
-    const windowId__state = this._getWindowStateMap(why);
-    for (const window of this._getWindows()) {
-      if (windowId__state.has(window.get_id()))
-        windowId__state.get(window.get_id()).restore(window);
-      else if (this._log >= LOG_DEBUG)
-        console.log(`${EXTENSION_LOG_NAME} ${why} did not find: ${window.get_id()} ${window.get_title()}`);
-    }
-  }
-}
-
-let displaySize__windowId__state;
-let _allWindowsStates;
-let _interval;
-let _lastSavedSize;
+const REFRESH_INTERVAL = 5000;
 
 export default class WindowStateManager extends Extension {
   /**
@@ -151,9 +16,14 @@ export default class WindowStateManager extends Extension {
    * done in GNOME Extensions, when you log in or when the screen is unlocked.
    */
   enable() {
-    displaySize__windowId__state = new Map();
-    _allWindowsStates = new AllWindowsStates(LOG_LEVEL);
-    _interval = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 5000, () => {
+    Logger.init(EXTENSION_LOG_NAME, LOG_LEVEL);
+    Logger.info("Extension enabled.");
+
+    this.windowStates = new WindowStates();
+    this.lastRefreshedSize = 'None';
+
+    // Start timer to refresh window states
+    this.refreshInterval = GLib.timeout_add(GLib.PRIORITY_DEFAULT, REFRESH_INTERVAL, () => {
       this._refreshState();
       return GLib.SOURCE_CONTINUE;
     });
@@ -164,16 +34,14 @@ export default class WindowStateManager extends Extension {
    * GNOME Extensions or when the screen locks.
    */
   disable() {
-    /**
-     * Window states are stored in the `displaySize__windowId__state` variable.
-     * This variable gets initialized in the enable() and destroyed in the disable().
-     * However to make this extension useful, the window states should survive device 
-     * lock and unlock events. For this reason, the `session-mode` of `unlock-dialog` is used.
-     */
-    _allWindowsStates = null;
-    displaySize__windowId__state = null;
-    if (_interval)
-      GLib.source_remove(_interval);
+    Logger.info("Extension disabled.");
+
+    // Disable the timer
+    if (this.refreshInterval)
+      GLib.source_remove(this.refreshInterval);
+
+    this.lastRefreshedSize = null;
+    this.windowStates = null;
   }
 
   /**
@@ -181,13 +49,15 @@ export default class WindowStateManager extends Extension {
    * and restore window position if needed
    */
   _refreshState() {
-    const size = JSON.stringify(global.display.get_size());
-    if (size != _lastSavedSize) {
-      console.log(`${EXTENSION_LOG_NAME} Screen size changed (old: ${_lastSavedSize}, new: ${size}). Restoring saved layout...`)
-      _allWindowsStates.restoreWindowPositions("AutoRestore");
+    // Get the current screen size
+    const size = this.windowStates?.getWindowSizeKey();
+
+    if (size != this.lastRefreshedSize) {
+      Logger.info(`Screen size changed (${this.lastRefreshedSize} => ${size}). Restoring saved layout...`);
+      this.windowStates?.restoreWindowPositions();
     } else {
-      _allWindowsStates.saveWindowPositions("AutoSave");
+      this.windowStates?.saveWindowPositions();
     }
-    _lastSavedSize = size;
+    this.lastRefreshedSize = size;
   }
 }

--- a/extension.js
+++ b/extension.js
@@ -7,7 +7,7 @@ import { WindowStates } from './lib/extension/windowstate.js';
 
 // Logging configuration
 const EXTENSION_LOG_NAME = 'Window State Manager';
-const LOG_LEVEL = Logger.LOG_LEVELS.INFO;
+const LOG_LEVEL = Logger.LOG_LEVELS.DEBUG;
 
 export default class WindowStateManager extends Extension {
   /**

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,9 @@
-#!/bin/sh
+#!/bin/bash -e
 
-BASEDIR=.local/share/gnome-shell/extensions
-DIR=window-state-manager@kishorv06.github.io
-URL=https://github.com/kishorv06/window-state-manager.git
+BASEDIR="$HOME/.local/share/gnome-shell/extensions"
+DIR="window-state-manager@kishorv06.github.io"
+URL="https://github.com/kishorv06/window-state-manager.git"
 
-which git 2> /dev/null > /dev/null || ( echo Could not find Git ; exit 1 )
 which gnome-shell 2> /dev/null > /dev/null || ( echo Could not find GNOME Shell ; exit 1 )
 
 GSVERSION=$(gnome-shell --version | awk '{ print $3; }')
@@ -19,24 +18,31 @@ case $GSVERSION in
 	;;
 esac
 
-cd $HOME || exit
 mkdir -p ${BASEDIR} 2> /dev/null
+echo "Installing to ${BASEDIR}/${DIR}..."
 
-cd ${BASEDIR} || ( echo Could not change to ${BASEDIR} ; exit 2 )
-
-echo Using ${HOME}/${BASEDIR}/${DIR}
-
-if [ -d ${DIR}/.git ]; then
-	echo Already installed, updating...
-	cd ${DIR} || exit
-	git pull
+if [ "$1" == "--install-from-local" ]; then
+	# Install from current directory
+	mkdir -p "${BASEDIR}/${DIR}" 2> /dev/null
+	cp -r . "${BASEDIR}/${DIR}"
 else
-	if [ -d ${DIR} ]; then
-		echo Found a previous installation.
-		echo If you are sure you want to replace it, please delete this folder and retry.
-		exit 4
+	# Install from git
+	which git 2> /dev/null > /dev/null || ( echo Could not find Git ; exit 1 )
+
+	cd ${BASEDIR} || ( echo Could not change to ${BASEDIR} ; exit 2 )
+
+	if [ -d ${DIR}/.git ]; then
+		echo "Extension already installed. Updating..."
+		cd ${DIR} || exit
+		git pull
 	else
-		git clone ${URL} ${DIR} || exit 3
+		if [ -d ${DIR} ]; then
+			echo Found a previous installation.
+			echo If you are sure you want to replace it, please delete this folder and retry.
+			exit 4
+		else
+			git clone ${URL} ${DIR} || exit 3
+		fi
 	fi
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ echo "Installing to ${BASEDIR}/${DIR}..."
 if [ "$1" == "--install-from-local" ]; then
 	# Install from current directory
 	mkdir -p "${BASEDIR}/${DIR}" 2> /dev/null
-	cp -r . "${BASEDIR}/${DIR}"
+	rsync -r --exclude '.git' . "${BASEDIR}/${DIR}"
 else
 	# Install from git
 	which git 2> /dev/null > /dev/null || ( echo Could not find Git ; exit 1 )

--- a/lib/common/logger.js
+++ b/lib/common/logger.js
@@ -1,0 +1,39 @@
+export class Logger {
+
+    // Name used for logging
+    static LOG_NAME
+
+    // Current log level
+    static LOG_LEVEL
+
+    // Log levels
+    static LOG_LEVELS = {
+        NOTHING: 0,
+        ERROR: 1,
+        INFO: 2,
+        DEBUG: 3,
+        EVERYTHING: 4,
+    }
+
+    // Initlization function
+    static init(logname, level) {
+        this.LOG_NAME = logname;
+        this.LOG_LEVEL = level;
+    }
+
+    static debug(...args) {
+        if (this.LOG_LEVEL > this.LOG_LEVELS.INFO) console.debug(`[${this.LOG_NAME}] [DEBUG]`, ...args)
+    }
+
+    static info(...args) {
+        if (this.LOG_LEVEL > this.LOG_LEVELS.ERROR) console.info(`[${this.LOG_NAME}] [INFO]`, ...args)
+    }
+
+    static error(...args) {
+        if (this.LOG_LEVEL > this.LOG_LEVELS.NOTHING) console.error(`[${this.LOG_NAME}] [ERROR]`, ...args)
+    }
+
+    static log(...args) {
+        if (this.LOG_LEVEL > this.LOG_LEVELS.NOTHING) console.log(`[${this.LOG_NAME}] [LOG]`, ...args)
+    }
+}

--- a/lib/common/logger.js
+++ b/lib/common/logger.js
@@ -22,15 +22,15 @@ export class Logger {
     }
 
     static debug(...args) {
-        if (this.LOG_LEVEL > this.LOG_LEVELS.INFO) console.debug(`[${this.LOG_NAME}] [DEBUG]`, ...args)
+        if (this.LOG_LEVEL > this.LOG_LEVELS.INFO) console.log(`[${this.LOG_NAME}] [DEBUG]`, ...args)
     }
 
     static info(...args) {
-        if (this.LOG_LEVEL > this.LOG_LEVELS.ERROR) console.info(`[${this.LOG_NAME}] [INFO]`, ...args)
+        if (this.LOG_LEVEL > this.LOG_LEVELS.ERROR) console.log(`[${this.LOG_NAME}] [INFO]`, ...args)
     }
 
     static error(...args) {
-        if (this.LOG_LEVEL > this.LOG_LEVELS.NOTHING) console.error(`[${this.LOG_NAME}] [ERROR]`, ...args)
+        if (this.LOG_LEVEL > this.LOG_LEVELS.NOTHING) console.log(`[${this.LOG_NAME}] [ERROR]`, ...args)
     }
 
     static log(...args) {

--- a/lib/extension/window.js
+++ b/lib/extension/window.js
@@ -1,0 +1,84 @@
+import Meta from "gi://Meta";
+
+import { Logger } from '../common/logger.js';
+
+// This class stores the state of a window
+export class Window {
+    constructor(window) {
+        this._rect = window.get_frame_rect();
+        this._maximized = window.get_maximized();
+        this._minimized = window.minimized;
+
+        // The following are only used for logging
+        this._fullscreen = window.fullscreen;
+        this._id = window.get_id();
+        this._title = window.get_title();
+    }
+
+    toString() {
+        const r = this._rect;
+        return `x:${r.x}, y:${r.y}, w:${r.width}, h:${r.height}, isMaximized:${this._maximized}, ` +
+            `isMinimized:${this._minimized}, isFullscreen:${this._fullscreen}, id:${this._id}, title:${this._title}`;
+    }
+
+    restore(currentWindow) {
+        if (!this._equalRect(currentWindow)) {
+            if (currentWindow.get_maximized())
+                currentWindow.unmaximize(Meta.MaximizeFlags.BOTH);
+            this._moveResizeFrame(currentWindow);
+        }
+        this._setMaximized(currentWindow);
+        this._setMinimized(currentWindow);
+        this._logDifferences(currentWindow);
+    }
+
+    _equalRect(window) {
+        const r = window.get_frame_rect();
+        return this._rect.x === r.x && this._rect.y === r.y &&
+            this._rect.width === r.width && this._rect.height === r.height;
+    }
+
+    _moveResizeFrame(window) {
+        // Is it correct to set user_op => true?  Is this performing a user operation?
+        window.move_resize_frame(true, this._rect.x, this._rect.y, this._rect.width, this._rect.height);
+    }
+
+    _setMaximized(window) {
+        if (window.get_maximized() !== this._maximized) {
+            if (this._maximized)
+                window.maximize(this._maximized);
+            else
+                window.unmaximize(Meta.MaximizeFlags.BOTH);
+        }
+    }
+
+    _setMinimized(window) {
+        if (window.minimized !== this._minimized) {
+            if (this._minimized)
+                window.minimize();
+            else
+                window.unminimize();
+        }
+    }
+
+    _logDifferences(window) {
+        let hasDiffs = false;
+        if (window.minimized !== this._minimized) {
+            Logger.error(`Wrong minimized: ${window.minimized()}, title:${this._title}`);
+            hasDiffs = true;
+        }
+        if (window.get_maximized() !== this._maximized) {
+            Logger.error(`Wrong maximized: ${window.get_maximized()}, title:${this._title}`);
+            hasDiffs = true;
+        }
+        // This test fails when there is a difference between saved and current maximization, though the window
+        // behaviour is correct.  Due to an asynchronous update?
+        if (!this._equalRect(window)) {
+            const r = window.get_frame_rect();
+            Logger.error(`Wrong rectangle: x:${r.x}, y:${r.y}, w:${r.width}, h:${r.height}, title:${this._title}`);
+            hasDiffs = true;
+        }
+        if (hasDiffs)
+            Logger.error(`Expecting: ${this}`);
+    }
+}

--- a/lib/extension/window.js
+++ b/lib/extension/window.js
@@ -64,21 +64,21 @@ export class Window {
     _logDifferences(window) {
         let hasDiffs = false;
         if (window.minimized !== this._minimized) {
-            Logger.error(`Wrong minimized: ${window.minimized()}, title:${this._title}`);
+            Logger.debug(`Wrong minimized: ${window.minimized()}, title:${this._title}`);
             hasDiffs = true;
         }
         if (window.get_maximized() !== this._maximized) {
-            Logger.error(`Wrong maximized: ${window.get_maximized()}, title:${this._title}`);
+            Logger.debug(`Wrong maximized: ${window.get_maximized()}, title:${this._title}`);
             hasDiffs = true;
         }
         // This test fails when there is a difference between saved and current maximization, though the window
         // behaviour is correct.  Due to an asynchronous update?
         if (!this._equalRect(window)) {
             const r = window.get_frame_rect();
-            Logger.error(`Wrong rectangle: x:${r.x}, y:${r.y}, w:${r.width}, h:${r.height}, title:${this._title}`);
+            Logger.debug(`Wrong rectangle: x:${r.x}, y:${r.y}, w:${r.width}, h:${r.height}, title:${this._title}`);
             hasDiffs = true;
         }
         if (hasDiffs)
-            Logger.error(`Expecting: ${this}`);
+            Logger.debug(`Expecting: ${this}`);
     }
 }

--- a/lib/extension/windowstate.js
+++ b/lib/extension/windowstate.js
@@ -1,0 +1,53 @@
+import { Logger } from '../common/logger.js';
+import { Window } from './window.js';
+
+export class WindowStates {
+
+    // Initializes the class with an old state, if available
+    constructor(states) {
+        if (states != null) {
+            this.windowStates = states;
+        } else {
+            this.windowStates = new Map();
+        }
+    }
+
+    _getWindows() {
+        return global.get_window_actors().map(a => a.meta_window).filter(w => !w.is_skip_taskbar());
+    }
+
+    _getWindowStateMap() {
+        // Generate key for the map
+        const displaySizeKey = this.getWindowSizeKey();
+        // Initialize the key, if it doesn't exist
+        if (!this.windowStates.has(displaySizeKey))
+            this.windowStates.set(displaySizeKey, new Map());
+        // Get state for current screen
+        const windowId__state = this.windowStates.get(displaySizeKey);
+        Logger.debug(`Map size: ${windowId__state.size}  display size: ${displaySizeKey}`);
+        return windowId__state;
+    }
+
+    getWindowSizeKey() {
+        return JSON.stringify(global.display.get_size());
+    }
+
+    saveWindowPositions() {
+        Logger.debug(`Saving window positions...`);
+        const windowId__state = this._getWindowStateMap();
+        windowId__state.clear();
+        for (const window of this._getWindows())
+            windowId__state.set(window.get_id(), new Window(window));
+    }
+
+    restoreWindowPositions() {
+        Logger.debug(`Restoring window positions...`);
+        const windowId__state = this._getWindowStateMap();
+        for (const window of this._getWindows()) {
+            if (windowId__state.has(window.get_id()))
+                windowId__state.get(window.get_id()).restore(window);
+            else
+                Logger.debug(`Did not find: ${window.get_id()} ${window.get_title()}`)
+        }
+    }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -2,13 +2,9 @@
 	"shell-version": [
 		"45"
 	],
-	"session-modes": [
-		"user",
-		"unlock-dialog"
-	],
 	"uuid": "window-state-manager@kishorv06.github.io",
 	"name": "Window State Manager",
 	"url": "https://github.com/kishorv06/window-state-manager",
-	"version": "2.0-git",
+	"version": "10",
 	"description": "Automatically remember and restore window state and positions. Useful when using Gnome with wayland in a multi-monitor setup. Some applications won't remember their location when monitors are connected or disconnected. This extension solves that problem by saving window state periodically and restoring it when screen arrangement is changed."
 }

--- a/metadata.json
+++ b/metadata.json
@@ -9,6 +9,6 @@
 	"uuid": "window-state-manager@kishorv06.github.io",
 	"name": "Window State Manager",
 	"url": "https://github.com/kishorv06/window-state-manager",
-	"version": 4,
+	"version": "2.0-git",
 	"description": "Automatically remember and restore window state and positions. Useful when using Gnome with wayland in a multi-monitor setup. Some applications won't remember their location when monitors are connected or disconnected. This extension solves that problem by saving window state periodically and restoring it when screen arrangement is changed."
 }

--- a/metadata.json
+++ b/metadata.json
@@ -2,6 +2,10 @@
 	"shell-version": [
 		"45"
 	],
+	"session-modes": [
+		"user",
+		"unlock-dialog"
+	],
 	"uuid": "window-state-manager@kishorv06.github.io",
 	"name": "Window State Manager",
 	"url": "https://github.com/kishorv06/window-state-manager",


### PR DESCRIPTION
- Rewrite the extension in a structured manner
- Use signals instead of saving and restoring states periodically
- Run in `unlock-dialog` mode to  persist window states
- Support Gnome 45

Resolves #6 
Resolves #7 